### PR TITLE
Add basic release automation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,37 @@
 name: CI
 on: push
+
 jobs:
-  build:
-    name: Test
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
+      - name: Restore npm cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
       - run: nix develop --command npm install
       - run: nix develop --command npm test
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: test
+    if: ${{ github.ref_name == 'main' }}
+    env:
+      NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+      - name: Restore npm cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: nix develop --command npm clean-install
+      - run: nix develop --command npm run release:candidate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Type of version bump.'
+        default: patch
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GITHUB_ACTOR: ${{ github.actor }}
+      NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+      VERSION_TO_RELEASE: ${{ inputs.version }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+      - run: nix develop --command npm clean-install
+      - run: nix develop --command npm run release:stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [UNRELEASED]
 
+### Added
+
+- Merges to `main` automatically publish an `@rc` release.
+
 ## [0.5.0] - 2024-04-28
 
 ### Changed

--- a/bin/publish-rc
+++ b/bin/publish-rc
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+date_string="$(date +%Y-%m-%d)"
+short_rev="$(git rev-parse --short HEAD)"
+version_string="${npm_package_version}-${date_string}.${short_rev}"
+
+npm version --no-git-tag-version "${version_string}"
+npm publish --tag rc

--- a/bin/publish-stable
+++ b/bin/publish-stable
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bump the version, update the changelog, push a tag.
+
+echo "Beginning release process: ${VERSION_TO_RELEASE}"
+
+echo 'Bumping package version.'
+npm version --no-git-tag "${VERSION_TO_RELEASE}"
+new_version="$(npm run -s print-pkg-version)"
+
+echo 'Updating changelog.'
+npx changelog --release "${new_version}"
+npx changelog --create
+npx prettier --write CHANGELOG.md
+
+echo 'Generating release notes.'
+release_notes="$(node --input-type=module -e "
+import { parser } from 'keep-a-changelog';
+import { readFile } from 'node:fs/promises';
+import { format, resolveConfig } from 'prettier';
+
+const [fileContents, prettierConfig] = await Promise.all([
+  readFile('CHANGELOG.md', 'utf8'),
+  resolveConfig(),
+])
+
+const { releases } = parser(fileContents)
+const formattedChangelog = await format(String(releases[1]), {
+  ...prettierConfig,
+  parser: 'markdown',
+})
+
+console.log(formattedChangelog);
+")"
+
+# Allow `#` characters in git commit messages. Enables markdown.
+git config core.commentChar '~'
+
+echo 'Setting comitter identity.'
+git config user.name 'Release Bot'
+git config user.email 'release-bot@users.noreply.github.com'
+
+echo 'Committing changelog.'
+git add -- CHANGELOG.md package.json package-lock.json
+git commit --message "v${new_version}"
+
+echo 'Creating git tag.'
+git tag -a "v${new_version}" -m "v${new_version}"
+
+# Pushing a tag triggers the stable release.
+git push origin "$(git rev-parse --abbrev-ref HEAD)"
+git push --tags
+
+# Associate the tag with a GitHub release.
+gh release create "v${new_version}" --verify-tag --title "v${new_version}" --notes "${release_notes}"
+
+echo 'Publishing to npm.'
+npm publish

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "eslint": "9.32.0",
         "jest": "30.0.5",
         "jest-environment-jsdom": "30.0.5",
+        "keep-a-changelog": "^2.6.2",
         "prettier": "3.6.2",
         "ts-jest": "29.4.1",
         "typescript": "5.8.3",
@@ -684,6 +685,50 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@deno/shim-deno": {
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@deno/shim-deno/-/shim-deno-0.18.2.tgz",
+      "integrity": "sha512-oQ0CVmOio63wlhwQF75zA4ioolPvOwAoK0yuzcS5bDC1JUvH3y1GS8xPh8EOpcoDQRU4FTG8OQfxhpR+c6DrzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deno/shim-deno-test": "^0.5.0",
+        "which": "^4.0.0"
+      }
+    },
+    "node_modules/@deno/shim-deno-test": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@deno/shim-deno-test/-/shim-deno-test-0.5.0.tgz",
+      "integrity": "sha512-4nMhecpGlPi0cSzT67L+Tm+GOJqvuk8gqHBziqcUQOarnuIax1z96/gJHCSIz2Z0zhxE6Rzwb3IZXPtFh51j+w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@deno/shim-deno/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@deno/shim-deno/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -6185,6 +6230,19 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keep-a-changelog": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/keep-a-changelog/-/keep-a-changelog-2.6.2.tgz",
+      "integrity": "sha512-YSebqNvqzsTcDYJ4jxO1w8vFa74J0R+8Ks0ZOtHQwdJho2EPuzOtAgRkpMd/0NxiQ0toqJgl7CPMz1urZs9pxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deno/shim-deno": "~0.18.0"
+      },
+      "bin": {
+        "changelog": "esm/bin.js"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "module": "./dist/media-devices.js",
   "main": "./dist/media-devices.umd.cjs",
   "types": "./dist/media-devices.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": {
       "types": "./dist/media-devices.d.ts",
@@ -32,7 +35,10 @@
     "test": "./bin/run-tests",
     "test:unit": "jest --color",
     "test:lint": "eslint src --color",
-    "test:fmt": "prettier --check src"
+    "test:fmt": "prettier --check src",
+    "print-pkg-version": "echo ${npm_package_version}",
+    "release:candidate": "./bin/publish-rc",
+    "release:stable": "./bin/publish-stable"
   },
   "prettier": {
     "singleQuote": true,
@@ -52,6 +58,7 @@
     "eslint": "9.32.0",
     "jest": "30.0.5",
     "jest-environment-jsdom": "30.0.5",
+    "keep-a-changelog": "^2.6.2",
     "prettier": "3.6.2",
     "ts-jest": "29.4.1",
     "typescript": "5.8.3",


### PR DESCRIPTION
Any merge to `main` triggers an `rc` release. A manual dispatch workflow triggers a stable release by updating the changelog, bumping the version, committing and tagging, then creating a GitHub release and publishing to npm.

This is identical to my process in [@retreon/cells](https://github.com/retreon/cells).

Fixes #656